### PR TITLE
feat: Strategy Pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# go-design-patterns
-Design Patterns for Go - adapted from Head First Design Patterns.
+# Go Design Patterns
+
+Design Patterns for Go, adapted from Head First Design Patterns (2nd Edition) by Eric Freeman and
+Elisabeth Robson.
+
+## Patterns
+
+1. The "Strategy" pattern: [doc](./strategy/doc.go)
+
+## License
+
+Code here is licensed under the MIT [License](./LICENSE)

--- a/cmd/duck_simulator.go
+++ b/cmd/duck_simulator.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"github.com/adambkaplan/go-design-patterns/strategy/behavior"
+	"github.com/adambkaplan/go-design-patterns/strategy/duck"
+)
+
+func RunDuckSimulator() {
+	mallardDuck := duck.NewMallardDuck()
+	mallardDuck.PerformQuack()
+	mallardDuck.PerformFly()
+
+	modelDuck := duck.NewModelDuck()
+	modelDuck.PerformFly()
+	modelDuck.FlyBehavior = behavior.FlyRocketPowered{}
+	modelDuck.PerformFly()
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,19 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
 package main
 
+import (
+	"fmt"
+
+	"github.com/adambkaplan/go-design-patterns/cmd"
+)
+
 func main() {
-	// This is a simple Go program that prints "Hello, World!" to the console.
-	// It will be updated as more design patterns are added.
-	println("Hello, World!")
+	// This is simple Go program that prints the outputs of the various pattern "test harnesses".
+	fmt.Println("Head First Design Patterns in Go!")
+
+	fmt.Println("Pattern 1: Strategy Pattern with the Duck Simulator")
+	cmd.RunDuckSimulator()
 }

--- a/strategy/behavior/behaviors.go
+++ b/strategy/behavior/behaviors.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
+package behavior
+
+import "fmt"
+
+// Flyable represents anything that has flying behavior.
+type Flyable interface {
+	Fly()
+}
+
+// FlyWithWings flies with wings.
+type FlyWithWings struct{}
+
+func (f FlyWithWings) Fly() {
+	fmt.Println("I'm flying with wings!")
+}
+
+// FlyNoWay doesn't fly.
+type FlyNoWay struct{}
+
+func (f FlyNoWay) Fly() {
+	fmt.Println("I can't fly")
+}
+
+// FlyRocketPowered flies with rockets.
+type FlyRocketPowered struct{}
+
+func (f FlyRocketPowered) Fly() {
+	fmt.Println("I'm flying with a rocket!")
+}
+
+// Quackable represents anything that has quacking behavior.
+type Quackable interface {
+	Quack()
+}
+
+// Quack does your typical duck quack.
+type Quack struct{}
+
+func (q Quack) Quack() {
+	fmt.Println("Quack!")
+}
+
+// MuteQuack is silent.
+type MuteQuack struct{}
+
+func (m MuteQuack) Quack() {
+	fmt.Println("<< Silence >>")
+}
+
+// Squeak is the quack that sounds like a squeak, perhaps from a rubber duck.
+type Squeak struct{}
+
+func (s Squeak) Quack() {
+	fmt.Println("Squeak!")
+}

--- a/strategy/behavior/doc.go
+++ b/strategy/behavior/doc.go
@@ -1,0 +1,6 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
+// behavior contains all the behaviors that can be exhibited in the duck simulator.
+package behavior

--- a/strategy/doc.go
+++ b/strategy/doc.go
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
+// strategy contains an example of the Strategy design pattern using golang. The package is divided
+// into two sub-packages:
+//
+// 1. `behavior` - this contains all of the behaviors we want in the "duck simulator."
+//
+// 2. `duck` - this contains all the types of ducks that can be added to the simulator.
+package strategy

--- a/strategy/duck/doc.go
+++ b/strategy/duck/doc.go
@@ -1,0 +1,6 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
+// duck contains all the ducks that can fly and quack in the duck simulator.
+package duck

--- a/strategy/duck/ducks.go
+++ b/strategy/duck/ducks.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2025 Adam Kaplan
+//
+// SPDX-License-Identifier: MIT
+
+package duck
+
+import (
+	"fmt"
+
+	"github.com/adambkaplan/go-design-patterns/strategy/behavior"
+)
+
+// duck is the equivalent of an "abstract class" in Go. It is internal to the `duck` package and
+// can't be instantiated outside of the package. "Sub-classes" inherit the `duck` behavior through
+// type embedding.
+type duck struct {
+	FlyBehavior   behavior.Flyable
+	QuackBehavior behavior.Quackable
+}
+
+// PerformFly is a method that performs the fly behavior of a Duck.
+// If the Duck has a FlyBehavior set, it will be called.
+// Otherwise, the method will return without performing any action.
+//
+// Assisted by watsonx Code Assistant
+func (d *duck) PerformFly() {
+	if d.FlyBehavior != nil {
+		d.FlyBehavior.Fly()
+	}
+	return
+}
+
+// PerformQuack is a method that performs the quack behavior.
+// It takes no input parameters and returns nothing.
+//
+// Assisted by watsonx Code Assistant
+func (d *duck) PerformQuack() {
+	if d.QuackBehavior != nil {
+		d.QuackBehavior.Quack()
+	}
+	return
+}
+
+// Swim is a method that makes the duck swim.
+// It prints a message to the standard output and returns nothing.
+//
+// Assisted by watsonx Code Assistant
+func (d *duck) Swim() {
+	fmt.Println("All ducks float, even decoys!")
+	return
+}
+
+// MallardDuck represents a real Mallard duck.
+type MallardDuck struct {
+	duck
+}
+
+// NewMallardDuck creates a new MallardDuck instance.
+//
+// Assisted by watsonx Code Assistant
+func NewMallardDuck() *MallardDuck {
+	return &MallardDuck{
+		duck: duck{
+			FlyBehavior:   behavior.FlyWithWings{},
+			QuackBehavior: behavior.Quack{},
+		},
+	}
+}
+
+// Display shows the duck to the console.
+func (m *MallardDuck) Display() {
+	fmt.Println("I'm a real Mallard duck")
+}
+
+// ModelDuck represents a model duck that can be adapted.
+type ModelDuck struct {
+	duck
+}
+
+// NewModelDuck creates a new ModelDuck instance.
+func NewModelDuck() *ModelDuck {
+	return &ModelDuck{
+		duck: duck{
+			FlyBehavior:   behavior.FlyNoWay{},
+			QuackBehavior: behavior.MuteQuack{},
+		},
+	}
+}
+
+// Display shows the duck to the console.
+func (m *ModelDuck) Display() {
+	fmt.Println("I'm a model duck")
+}


### PR DESCRIPTION
Implementation of the "strategy pattern", ported to golang. This adheres to Java code described in the Heads Up Design Patterns book - most notably its use of printing output to Stdout and not using JUnit to execute automated tests.