### PR TITLE
doc: Add Notes on Design and Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,46 @@
 Design Patterns for Go - adapted from Head First Design Patterns (2nd Edition) by Eric Freeman and
 Elisabeth Robson.
 
-## Notes
+## Does Go Need Design Patterns?
 
 This repository adapts the design patterns in the book to the Go programming language. Unlike Java
 (which is used as the canoncial example in the book), Go is **not** an object-oriented programming
-language. Patterns that rely on polymorphism/class inheritance will thus be modified to rely less
-on these techniques. Some "inherited" code may be copied, and that is okay;
-[a little copying is better than a little dependency](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=9m28s).
+language. Some patterns translate well to Golang; others, not so much.
 
 This repository will also take a [test-driven development](https://www.agilealliance.org/glossary/tdd/)
 approach to writing code. Most structs and functions will be verified by tests using the
 [Ginkgo](https://onsi.github.io/ginkgo/) test framework. This framework emphasizes testing
 _behaviors_, which makes the test suite more resilient to change.
+
+### Design Basics
+
+- **Abstraction**: Only expose what clients/callers need to know. Hide what is not necessary.
+  Present _what_ an entity does, not _how_ it does it.
+- **Encapsulation**: Group together information and behaviors that logically belong together.
+  Control access to information whose state needs to be tightly managed.
+- **Composition**: Share behavior through combinations. Inheritance and polymorphisim do not exist
+  in go (mostly).
+- **Valuation**: Unlike Java and other object-oriented languages, errors and functions are values
+  in Go and can be referenced just like a `string` or `int`.
+
+### Principles and Proverbs
+
+- Encapsulate what varies.
+- Favor composition.
+- Program to interfaces ~~, not implementations~~ when the interface is all you need.
+- The bigger the interface, the weaker the abstraction [proverb](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=5m17s).
+- Strive for loose coupling between entites that interact.
+- Make the zero value useful [proverb](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=6m25s).
+- A little copying is better than a little dependency [proverb](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=9m28s).
+- Clear is better than clever [proverb](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=14m35s).
+- Handle errors gracefully [proverb](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=17m25s).
+- Don't communicate by sharing memory, share memory by communicating [proverb](https://www.youtube.com/watch?v=PAAkCSZUG1c&t=2m48s).
+
+## Patterns
+
+1. [Strategy Pattern](./strategy/README.md)
+2. [Observer Pattern](./observer/README.md)
+3. [Decorator Pattern](./decorator/README.md)
 
 ## License
 

--- a/decorator/README.md
+++ b/decorator/README.md
@@ -1,0 +1,10 @@
+# Decorator Pattern
+
+Developers often call the Decorator pattern "object wrapping," where a class/object extends
+functionality by including a field with the same interface/supertype. In this contrived example,
+a hypothetical "beverage" is decorated with the extras a customer may add (milk, whipped cream,
+etc.).
+
+The implementation takes advantage of golang struct embedding to extend the capabilities of the
+"Condiment" decorators. Unlike Java or other object-oriented languages, effective struct embedding
+requires the "base" struct to be exported and useful.

--- a/observer/README.md
+++ b/observer/README.md
@@ -1,0 +1,9 @@
+# Observer Pattern
+
+In the observer pattern, an "observing" resource registers with a source "subject" resource, and by
+doing so receives notifications of changes. Many front-end developers implicitly use this pattern
+by registering callback functions with buttons and other visual elements.
+
+This implementation deviates from the "Head First" implementation to take advantage of Golang 
+concurrency primitives (goroutines and channels). In doing so, it adds further loose coupling
+between the Subject and Observer.

--- a/strategy/README.md
+++ b/strategy/README.md
@@ -1,0 +1,17 @@
+# Strategy Pattern
+
+The Strategy pattern is used to encapsulate object behavior that can change at runtime. In the
+book's example, a hypothetical "duck simulator" presents an assortment of ducks on screen, each
+type with their own "flying" and "quacking" behavior. Each duck type has a default flying and
+quacking behavior, however this can change at runtime.
+
+The Strategy pattern example in "Head First Design Patterns" relies on Java's polymorphism
+model to provide an "abstract" implementation of a Duck. This contains all the method
+definitions of a "Duck" supertype and shared behavior, but requires concrete implementations
+to provide the remaining gaps.
+
+Golang eschews object-oriented polymorphism altogheter, favoring composition instead. This
+implementation uses a true interface to define the behavior of all ducks, and programs to it in
+the unit test suite. Code reuse is encouraged through a "GenericDuck" struct type, which
+provides a working interface implementation. The other duck types embed this struct, overriding
+functions as needed to alter behavior.

--- a/strategy/duck/doc.go
+++ b/strategy/duck/doc.go
@@ -1,13 +1,2 @@
 // duck defines the Duck interface and provides implementations for various kinds of Ducks.
 package duck
-
-// The Strategy pattern example in "Head First Design Patterns" relies on Java's polymorphism
-// model to provide an "abstract" implementation of a Duck. This contains all the method
-// definitions of a "Duck" supertype and shared behavior, but requires concrete implementations
-// to provide the remaining gaps.
-
-// Golang eschews object-oriented polymorphism altogheter, favoring composition instead. This
-// implementation uses a true interface to define the behavior of all ducks, and programs to it in
-// the unit test suite. Code reuse is encouraged through a "GenericDuck" struct type, which
-// provides a working interface implementation. The other duck types embed this struct, overriding
-// functions as needed to alter behavior.


### PR DESCRIPTION
Expanded the README with my own philosophies on design in Golang, and links to detailed READMEs for each pattern. Noted is the lack of polymorphism in Golang, which requires some patterns to significantly alter their implementations. Additional READMEs also provided for specific patterns.