### PR TITLE
feat: Add VSCode and IntelliJ Files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ go.work.sum
 # Build and test artifacts
 go-design-patterns
 coverage.html
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+
+


### PR DESCRIPTION
Add ignore files for IntelliJ and VSCode.

Assisted-by: Cursor